### PR TITLE
Fixed ECONNRESET crash on websocket upgrade

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -136,6 +136,9 @@ function ReverseProxy(opts) {
   }
 
   function websocketsUpgrade(req, socket, head) {
+    socket.on('error', function (err) {
+      log && log.error(err, 'WebSockets error');
+    });
     var src = _this._getSource(req);
     _this._getTarget(src, req).then(function (target) {
       log && log.info({ headers: req.headers, target: target }, 'upgrade to websockets');


### PR DESCRIPTION
Added an error event handler to WebSockets connection to prevent the process from crashing because of an unhandled error event. Fixes #188.